### PR TITLE
Feat: Add Custom Tags to http endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,8 +422,6 @@ custom:
          description: BazDescription
 ```
 
-Endpoints that are not attached to a custom tag, are still attached to the title ( which is the default tag ).
-
 ```yaml
 functions:
   createFunc:
@@ -435,6 +433,7 @@ functions:
             tag: FooBarTitle
 ```
 
+Endpoints that are not attached to a custom tag, are still attached to the title ( which is the default tag ).
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -403,6 +403,39 @@ The `responseHeaders/requestHeaders` section of the configuration allows you to 
 TypeScript generation for these isn't supported.    
 For information on how to specify these yourself, see [Response Headers](https://github.com/conqa/serverless-openapi-documentation#responseheaders-and-requestheaders) on the base plugin page.  
 
+##### `customTags`
+
+In some cases where a single serverless.yml contains endpoints which can be grouped differently,
+you can define custom tags as following:
+
+```yaml
+custom:
+  documentation:
+    title: 'Project'
+    description: DummyDescription
+
+    apiNamespace: ProjectApi
+    tags:
+       - name: FooBarTitle
+         description: FooBarDescription
+       - name: BazTitle
+         description: BazDescription
+```
+
+Endpoints that are not attached to a custom tag, are still attached to the title ( which is the default tag ).
+
+```yaml
+functions:
+  createFunc:
+    handler: handler.create
+    events:
+      - http:
+          documentation:
+            summary: "Create Function"
+            tag: FooBarTitle
+```
+
+
 ## Install
 
 This plugin is **an extension**.  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-openapi-typescript",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "An extension of @conqa/serverless-openapi-documentation that also generates your OpenAPI models from TypeScript",
   "main": "dist/index.js",
   "scripts": {

--- a/src/serverless-openapi-typescript.ts
+++ b/src/serverless-openapi-typescript.ts
@@ -189,8 +189,8 @@ export default class ServerlessOpenapiTypeScript {
         description: openApi.info.description
       }
     ];
-    const tags = this.serverless.service.custom.documentation?.tags;
-    if (tags) openApi.tags = openApi.tags.concat(tags)
+    const customTags = this.serverless.service.custom.documentation?.tags;
+    if (customTags) openApi.tags = openApi.tags.concat(customTags)
 
     Object.values(openApi.paths).forEach(path => {
       Object.values(path).forEach(method => {

--- a/src/serverless-openapi-typescript.ts
+++ b/src/serverless-openapi-typescript.ts
@@ -181,6 +181,7 @@ export default class ServerlessOpenapiTypeScript {
   }
 
   tagMethods(openApi) {
+
     const tagName = openApi.info.title;
     openApi.tags = [
       {
@@ -188,9 +189,20 @@ export default class ServerlessOpenapiTypeScript {
         description: openApi.info.description
       }
     ];
+    const tags = this.serverless.service.custom.documentation?.tags;
+    if (tags) openApi.tags = openApi.tags.concat(tags)
+
     Object.values(openApi.paths).forEach(path => {
       Object.values(path).forEach(method => {
-        method.tags = [tagName];
+        const httpEvent = this.functions[method.operationId]?.events?.find(
+            (e: ApiGatewayEvent) => e.http
+        ) as ApiGatewayEvent;
+        const http: HttpEvent = httpEvent.http;
+        if (http.documentation?.tag) {
+          method.tags = [http.documentation.tag];
+        } else {
+          method.tags = [tagName];
+        }
       });
     });
   }

--- a/test/fixtures/expect-openapi-custom-tags.yml
+++ b/test/fixtures/expect-openapi-custom-tags.yml
@@ -1,0 +1,123 @@
+openapi: 3.1.0
+components:
+  schemas:
+    ObjectType:
+      type: object
+      properties:
+        types:
+          type: array
+          items:
+            type: string
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/ObjectType'
+      additionalProperties: false
+    ProjectApi.CreateFunc.Request.Body:
+      type: object
+      properties:
+        data:
+          type: string
+        statusCode:
+          type: number
+        enable:
+          type: boolean
+        object:
+          $ref: '#/components/schemas/ObjectType'
+      required:
+        - data
+        - enable
+      additionalProperties: false
+    ProjectApi.CreateFunc.Response:
+      type: object
+      properties:
+        id:
+          type: string
+        uuid:
+          type: string
+      required:
+        - id
+        - uuid
+      additionalProperties: false
+    ProjectApi.GetFunc.Response:
+      type: object
+      properties:
+        data:
+          type: string
+      required:
+        - data
+      additionalProperties: false
+info:
+  title: Project
+  description: DummyDescription
+  version: e8c31aa8-7d0c-45cf-b44a-3c3ef1b3780b
+paths:
+  /create/{funcName}:
+    post:
+      operationId: createFunc
+      summary: Create Function
+      description: |
+        Create Function1
+        Create Function2
+        Create Function3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectApi.CreateFunc.Request.Body'
+        description: ''
+      parameters: []
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectApi.CreateFunc.Response'
+      tags:
+        - FooBarTitle
+  /delete/{funcName}:
+    delete:
+      operationId: deleteFunc
+      summary: Delete Function
+      description: Delete
+      parameters:
+        - name: funcName
+          in: path
+          description: ''
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Status 204 Response
+          content: {}
+      tags:
+        - Project
+  /get/{funcName}:
+    get:
+      operationId: getFunc
+      summary: Get Function
+      parameters:
+        - name: funcName
+          in: path
+          description: ''
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectApi.GetFunc.Response'
+      tags:
+        - BazTitle
+tags:
+  - name: Project
+    description: DummyDescription
+  - name: FooBarTitle
+    description: FooBarDescription
+  - name: BazTitle
+    description: BazDescription

--- a/test/fixtures/expect-openapi-custom-tags.yml
+++ b/test/fixtures/expect-openapi-custom-tags.yml
@@ -1,58 +1,18 @@
 openapi: 3.1.0
 components:
   schemas:
-    ObjectType:
-      type: object
-      properties:
-        types:
-          type: array
-          items:
-            type: string
-        children:
-          type: array
-          items:
-            $ref: '#/components/schemas/ObjectType'
-      additionalProperties: false
     ProjectApi.CreateFunc.Request.Body:
-      type: object
-      properties:
-        data:
-          type: string
-        statusCode:
-          type: number
-        enable:
-          type: boolean
-        object:
-          $ref: '#/components/schemas/ObjectType'
-      required:
-        - data
-        - enable
-      additionalProperties: false
+      type: 'null'
     ProjectApi.CreateFunc.Response:
-      type: object
-      properties:
-        id:
-          type: string
-        uuid:
-          type: string
-      required:
-        - id
-        - uuid
-      additionalProperties: false
+      type: 'null'
     ProjectApi.GetFunc.Response:
-      type: object
-      properties:
-        data:
-          type: string
-      required:
-        - data
-      additionalProperties: false
+      type: 'null'
 info:
   title: Project
   description: DummyDescription
-  version: e8c31aa8-7d0c-45cf-b44a-3c3ef1b3780b
+  version: 3a5b57df-54e7-4dd2-9423-d4674809c816
 paths:
-  /create/{funcName}:
+  /create:
     post:
       operationId: createFunc
       summary: Create Function
@@ -76,35 +36,23 @@ paths:
                 $ref: '#/components/schemas/ProjectApi.CreateFunc.Response'
       tags:
         - FooBarTitle
-  /delete/{funcName}:
+  /delete:
     delete:
       operationId: deleteFunc
       summary: Delete Function
       description: Delete
-      parameters:
-        - name: funcName
-          in: path
-          description: ''
-          required: true
-          schema:
-            type: string
+      parameters: []
       responses:
         '204':
           description: Status 204 Response
           content: {}
       tags:
         - Project
-  /get/{funcName}:
+  /get:
     get:
       operationId: getFunc
       summary: Get Function
-      parameters:
-        - name: funcName
-          in: path
-          description: ''
-          required: true
-          schema:
-            type: string
+      parameters: []
       responses:
         '200':
           description: ''

--- a/test/serverless-custom-tags/api.d.ts
+++ b/test/serverless-custom-tags/api.d.ts
@@ -1,37 +1,14 @@
-interface ObjectType {
-    types?: string[];
-    children?: ObjectType[];
-}
-
 export namespace ProjectApi {
 
     export namespace CreateFunc {
         export namespace Request {
-            export type Body = {
-                data: string;
-                statusCode?: number;
-                enable: boolean;
-                object?: ObjectType;
-            };
+            export type Body = void
         }
 
-        export type Response = {
-            id: string;
-            uuid: string;
-        };
+        export type Response = void
     }
 
     export namespace GetFunc {
-        export type Response = {
-            data: string;
-        };
-    }
-
-    export namespace DeleteFunc {
-        export namespace Request {
-            export type Body = {
-                id: string;
-            };
-        }
+        export type Response = void
     }
 }

--- a/test/serverless-custom-tags/api.d.ts
+++ b/test/serverless-custom-tags/api.d.ts
@@ -1,0 +1,37 @@
+interface ObjectType {
+    types?: string[];
+    children?: ObjectType[];
+}
+
+export namespace ProjectApi {
+
+    export namespace CreateFunc {
+        export namespace Request {
+            export type Body = {
+                data: string;
+                statusCode?: number;
+                enable: boolean;
+                object?: ObjectType;
+            };
+        }
+
+        export type Response = {
+            id: string;
+            uuid: string;
+        };
+    }
+
+    export namespace GetFunc {
+        export type Response = {
+            data: string;
+        };
+    }
+
+    export namespace DeleteFunc {
+        export namespace Request {
+            export type Body = {
+                id: string;
+            };
+        }
+    }
+}

--- a/test/serverless-custom-tags/resources/serverless.yml
+++ b/test/serverless-custom-tags/resources/serverless.yml
@@ -10,7 +10,6 @@ custom:
   documentation:
     title: 'Project'
     description: DummyDescription
-
     apiNamespace: ProjectApi
     tags:
        - name: FooBarTitle
@@ -31,7 +30,7 @@ functions:
               Create Function1
               Create Function2
               Create Function3
-          path: create/{funcName}
+          path: create
           method: post
 
   deleteFunc:
@@ -41,12 +40,8 @@ functions:
           documentation:
             summary: "Delete Function"
             description: "Delete"
-          path: delete/{funcName}
+          path: delete
           method: delete
-          request:
-            parameters:
-              paths:
-                funcName: true
 
   getFunc:
     handler: handler.update
@@ -55,10 +50,6 @@ functions:
           documentation:
             summary: "Get Function"
             tag: BazTitle
-          path: get/{funcName}
+          path: get
           method: get
-          request:
-            parameters:
-              paths:
-                funcName: true
 

--- a/test/serverless-custom-tags/resources/serverless.yml
+++ b/test/serverless-custom-tags/resources/serverless.yml
@@ -1,0 +1,64 @@
+service: serverless-openapi-typescript-demo
+provider:
+  name: aws
+
+plugins:
+  - ../node_modules/@conqa/serverless-openapi-documentation
+  - ../src/index
+
+custom:
+  documentation:
+    title: 'Project'
+    description: DummyDescription
+
+    apiNamespace: ProjectApi
+    tags:
+       - name: FooBarTitle
+         description: FooBarDescription
+       - name: BazTitle
+         description: BazDescription
+
+
+functions:
+  createFunc:
+    handler: handler.create
+    events:
+      - http:
+          documentation:
+            summary: "Create Function"
+            tag: FooBarTitle
+            description: |
+              Create Function1
+              Create Function2
+              Create Function3
+          path: create/{funcName}
+          method: post
+
+  deleteFunc:
+    handler: handler.delete
+    events:
+      - http:
+          documentation:
+            summary: "Delete Function"
+            description: "Delete"
+          path: delete/{funcName}
+          method: delete
+          request:
+            parameters:
+              paths:
+                funcName: true
+
+  getFunc:
+    handler: handler.update
+    events:
+      - http:
+          documentation:
+            summary: "Get Function"
+            tag: BazTitle
+          path: get/{funcName}
+          method: get
+          request:
+            parameters:
+              paths:
+                funcName: true
+

--- a/test/serverless-openapi-typescript.spec.ts
+++ b/test/serverless-openapi-typescript.spec.ts
@@ -13,8 +13,8 @@ jest.setTimeout(60000);
 describe('ServerlessOpenapiTypeScript', () => {
     describe.each`
     testCase         | projectName
-    ${'FullProject'} | ${'full'}
-    ${'CustomTags'}  | ${'custom-tags'}
+    ${'Full Project'} | ${'full'}
+    ${'Custom Tags'}  | ${'custom-tags'}
     `('when using $testCase', ( { projectName } ) => {
 
         beforeEach(async () => {

--- a/test/serverless-openapi-typescript.spec.ts
+++ b/test/serverless-openapi-typescript.spec.ts
@@ -11,14 +11,17 @@ const existsAsync = promisify(fs.exists);
 jest.setTimeout(60000);
 
 describe('ServerlessOpenapiTypeScript', () => {
-    describe('FullProject', () => {
-        const projectName = 'full';
+    describe.each`
+    testCase         | projectName
+    ${'FullProject'} | ${'full'}
+    ${'CustomTags'}  | ${'custom-tags'}
+    `('when using $testCase', ( { projectName } ) => {
 
         beforeEach(async () => {
             await deleteOutputFile(projectName);
         });
 
-        it('should create full file with all types and docs', async () => {
+        it('should create the expected file', async () => {
             await runOpenApiGenerate(projectName);
 
             await assertYamlFilesEquals(projectName);


### PR DESCRIPTION
## Motivation
- We want to separate between Modules and Templates in our docs, currently they are grouped together because the endpoints are in the same serverless.yml

## What has been changed ?
- Concat custom tags to the tags array
- Attach the http-endpoints to the custom tags on `after` hook

![image](https://user-images.githubusercontent.com/83922349/137632566-bd9fa983-54f4-4fb5-8ad3-76f4b3c40e3f.png)
