### PR TITLE
Feat query param types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-openapi-typescript",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1876,6 +1876,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/serverless": {
+      "version": "1.78.39",
+      "resolved": "https://registry.npmjs.org/@types/serverless/-/serverless-1.78.39.tgz",
+      "integrity": "sha512-AcQ58tUIiNgFJw49p51JYOOwWftTJJlwIca5s3ONaSouwr7OC3m6Hpe7cM1K818sAwSttGq94V4B3O8sTdioCw==",
+      "dev": true
     },
     "@types/stack-utils": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-openapi-typescript",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "An extension of @conqa/serverless-openapi-documentation that also generates your OpenAPI models from TypeScript",
   "main": "dist/index.js",
   "scripts": {

--- a/src/serverless-openapi-typescript.ts
+++ b/src/serverless-openapi-typescript.ts
@@ -154,7 +154,13 @@ export default class ServerlessOpenapiTypeScript {
       // no-break;
       case 'get':
         const responseModelName = `${definitionPrefix}.Response`;
-        this.setModel(`${definitionPrefix}.Response`);
+        const queryParamsModelName = `${definitionPrefix}.Request.QueryParams`;
+        this.setModel(responseModelName);
+        try {
+            this.setModel(queryParamsModelName);
+        } catch(err) {
+          this.log(`Didn't find ${queryParamsModelName}`);
+        }
         set(httpEvent, 'documentation.methodResponses', [
           {
             statusCode: 200,

--- a/src/serverless-openapi-typescript.ts
+++ b/src/serverless-openapi-typescript.ts
@@ -181,7 +181,7 @@ export default class ServerlessOpenapiTypeScript {
                 try {
                     this.setModel(queryParamsModelName);
                 } catch (err) {
-                    this.log(`Didn't find ${queryParamsModelName}`);
+                    this.log(`Didn't find ${queryParamsModelName}, wont generate model`);
                 }
             })
         }

--- a/test/fixtures/expect-openapi-query-param-type.yml
+++ b/test/fixtures/expect-openapi-query-param-type.yml
@@ -1,71 +1,33 @@
 openapi: 3.1.0
 components:
   schemas:
-    ProjectApi.CreateFunc.Request.Body:
-      type: 'null'
-    ProjectApi.CreateFunc.Response:
-      type: 'null'
-    ProjectApi.GetFunc.Response:
+    ProjectApi.Func.Response:
       type: 'null'
 info:
   title: Project
   description: DummyDescription
-  version: 3a5b57df-54e7-4dd2-9423-d4674809c816
 paths:
-  /create:
-    post:
-      operationId: createFunc
-      summary: Create Function
-      description: |
-        Create Function1
-        Create Function2
-        Create Function3
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ProjectApi.CreateFunc.Request.Body'
-        description: ''
-      parameters: []
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ProjectApi.CreateFunc.Response'
-      tags:
-        - FooBarTitle
-  /delete:
-    delete:
-      operationId: deleteFunc
-      summary: Delete Function
-      description: Delete
-      parameters: []
-      responses:
-        '204':
-          description: Status 204 Response
-          content: {}
-      tags:
-        - Project
   /get:
     get:
-      operationId: getFunc
+      operationId: func
       summary: Get Function
-      parameters: []
+      parameters:
+        - name: name
+          in: query
+          description: ''
+          required: true
+          allowEmptyValue: false
+          schema:
+            type: string
       responses:
         '200':
           description: ''
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProjectApi.GetFunc.Response'
+                $ref: '#/components/schemas/ProjectApi.Func.Response'
       tags:
-        - BazTitle
+        - Project
 tags:
   - name: Project
     description: DummyDescription
-  - name: FooBarTitle
-    description: FooBarDescription
-  - name: BazTitle
-    description: BazDescription

--- a/test/fixtures/expect-openapi-query-param-type.yml
+++ b/test/fixtures/expect-openapi-query-param-type.yml
@@ -3,17 +3,11 @@ components:
   schemas:
     ProjectApi.Func.Response:
       type: 'null'
-    ProjectApi.Func.Request.QueryParams:
-      type: object
-      properties:
-        name:
-          type: string
-          enum:
-            - foo
-            - bar
-      required:
-        - name
-      additionalProperties: false
+    ProjectApi.Func.Request.QueryParams.name:
+      type: string
+      enum:
+        - foo
+        - bar
 info:
   title: Project
   description: DummyDescription
@@ -29,7 +23,7 @@ paths:
           required: true
           allowEmptyValue: false
           schema:
-            type: string
+            $ref: '#/components/schemas/ProjectApi.Func.Request.QueryParams.name'
       responses:
         '200':
           description: ''

--- a/test/fixtures/expect-openapi-query-param-type.yml
+++ b/test/fixtures/expect-openapi-query-param-type.yml
@@ -1,0 +1,71 @@
+openapi: 3.1.0
+components:
+  schemas:
+    ProjectApi.CreateFunc.Request.Body:
+      type: 'null'
+    ProjectApi.CreateFunc.Response:
+      type: 'null'
+    ProjectApi.GetFunc.Response:
+      type: 'null'
+info:
+  title: Project
+  description: DummyDescription
+  version: 3a5b57df-54e7-4dd2-9423-d4674809c816
+paths:
+  /create:
+    post:
+      operationId: createFunc
+      summary: Create Function
+      description: |
+        Create Function1
+        Create Function2
+        Create Function3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectApi.CreateFunc.Request.Body'
+        description: ''
+      parameters: []
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectApi.CreateFunc.Response'
+      tags:
+        - FooBarTitle
+  /delete:
+    delete:
+      operationId: deleteFunc
+      summary: Delete Function
+      description: Delete
+      parameters: []
+      responses:
+        '204':
+          description: Status 204 Response
+          content: {}
+      tags:
+        - Project
+  /get:
+    get:
+      operationId: getFunc
+      summary: Get Function
+      parameters: []
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectApi.GetFunc.Response'
+      tags:
+        - BazTitle
+tags:
+  - name: Project
+    description: DummyDescription
+  - name: FooBarTitle
+    description: FooBarDescription
+  - name: BazTitle
+    description: BazDescription

--- a/test/fixtures/expect-openapi-query-param-type.yml
+++ b/test/fixtures/expect-openapi-query-param-type.yml
@@ -24,6 +24,20 @@ paths:
           allowEmptyValue: false
           schema:
             $ref: '#/components/schemas/ProjectApi.Func.Request.QueryParams.name'
+        - name: other
+          in: query
+          description: ''
+          required: false
+          allowEmptyValue: false
+          schema:
+            type: string
+        - name: another
+          in: query
+          description: ''
+          required: true
+          allowEmptyValue: false
+          schema:
+            type: string
       responses:
         '200':
           description: ''

--- a/test/fixtures/expect-openapi-query-param-type.yml
+++ b/test/fixtures/expect-openapi-query-param-type.yml
@@ -3,6 +3,17 @@ components:
   schemas:
     ProjectApi.Func.Response:
       type: 'null'
+    ProjectApi.Func.Request.QueryParams:
+      type: object
+      properties:
+        name:
+          type: string
+          enum:
+            - foo
+            - bar
+      required:
+        - name
+      additionalProperties: false
 info:
   title: Project
   description: DummyDescription

--- a/test/serverless-openapi-typescript.spec.ts
+++ b/test/serverless-openapi-typescript.spec.ts
@@ -11,10 +11,10 @@ const existsAsync = promisify(fs.exists);
 jest.setTimeout(60000);
 
 describe('ServerlessOpenapiTypeScript', () => {
+    // ${'Custom Tags'}  | ${'custom-tags'}
+    // ${'Full Project'} | ${'full'}
     describe.each`
     testCase         | projectName
-    ${'Full Project'} | ${'full'}
-    ${'Custom Tags'}  | ${'custom-tags'}
     ${'Query Param Types'}  | ${'query-param-type'}
     `('when using $testCase', ({projectName}) => {
 
@@ -68,7 +68,7 @@ async function assertYamlFilesEquals(projectName: string): Promise<void> {
     const outputFile = `openapi-${projectName}.yml`;
     const expectFile = `test/fixtures/expect-openapi-${projectName}.yml`;
 
-    const [expectOutput, actualOutput] = await Promise.all([processYamlFileForTest(expectFile), processYamlFileForTest(outputFile)]);
+    const [actualOutput, expectOutput] = await Promise.all([processYamlFileForTest(expectFile), processYamlFileForTest(outputFile)]);
     expect(expectOutput).toEqual(actualOutput);
 }
 

--- a/test/serverless-openapi-typescript.spec.ts
+++ b/test/serverless-openapi-typescript.spec.ts
@@ -1,7 +1,7 @@
 import Serverless from "serverless";
 import path from "path";
 import fs from "fs";
-import { promisify } from "util";
+import {promisify} from "util";
 import yaml from "js-yaml";
 
 const readFileAsync = promisify(fs.readFile);
@@ -15,7 +15,8 @@ describe('ServerlessOpenapiTypeScript', () => {
     testCase         | projectName
     ${'Full Project'} | ${'full'}
     ${'Custom Tags'}  | ${'custom-tags'}
-    `('when using $testCase', ( { projectName } ) => {
+    ${'Query Param Types'}  | ${'query-param-type'}
+    `('when using $testCase', ({projectName}) => {
 
         beforeEach(async () => {
             await deleteOutputFile(projectName);
@@ -40,7 +41,7 @@ describe('ServerlessOpenapiTypeScript', () => {
         const projectName = 'not-documented';
 
         it('should throw an error when found function not documented', async () => {
-            await expect(runOpenApiGenerate(projectName)).rejects.toEqual(expect.objectContaining({ message: expect.stringContaining('deleteFunc')}));
+            await expect(runOpenApiGenerate(projectName)).rejects.toEqual(expect.objectContaining({message: expect.stringContaining('deleteFunc')}));
         });
     });
 
@@ -63,7 +64,7 @@ describe('ServerlessOpenapiTypeScript', () => {
     });
 });
 
-async function assertYamlFilesEquals(projectName: string) : Promise<void> {
+async function assertYamlFilesEquals(projectName: string): Promise<void> {
     const outputFile = `openapi-${projectName}.yml`;
     const expectFile = `test/fixtures/expect-openapi-${projectName}.yml`;
 
@@ -71,7 +72,7 @@ async function assertYamlFilesEquals(projectName: string) : Promise<void> {
     expect(expectOutput).toEqual(actualOutput);
 }
 
-async function processYamlFileForTest(path: string) : Promise<string> {
+async function processYamlFileForTest(path: string): Promise<string> {
     const yamlData = await readYaml(path);
     delete yamlData.info.version;
     return yaml.dump(yamlData);
@@ -84,8 +85,9 @@ async function readYaml(path: string) {
 
 async function deleteOutputFile(project) {
     try {
-        await deleteFileAsync( `openapi-${project}.yml`);
-    } catch {}
+        await deleteFileAsync(`openapi-${project}.yml`);
+    } catch {
+    }
 }
 
 async function runOpenApiGenerate(projectName) {

--- a/test/serverless-openapi-typescript.spec.ts
+++ b/test/serverless-openapi-typescript.spec.ts
@@ -11,10 +11,10 @@ const existsAsync = promisify(fs.exists);
 jest.setTimeout(60000);
 
 describe('ServerlessOpenapiTypeScript', () => {
-    // ${'Custom Tags'}  | ${'custom-tags'}
-    // ${'Full Project'} | ${'full'}
     describe.each`
     testCase         | projectName
+    ${'Custom Tags'}  | ${'custom-tags'}
+    ${'Full Project'} | ${'full'}
     ${'Query Param Types'}  | ${'query-param-type'}
     `('when using $testCase', ({projectName}) => {
 

--- a/test/serverless-query-param-type/api.d.ts
+++ b/test/serverless-query-param-type/api.d.ts
@@ -4,7 +4,6 @@ export namespace ProjectApi {
             export namespace QueryParams {
                 export type name =
                      'foo' | 'bar'
-
             }
         }
 

--- a/test/serverless-query-param-type/api.d.ts
+++ b/test/serverless-query-param-type/api.d.ts
@@ -1,0 +1,11 @@
+export namespace ProjectApi {
+    export namespace Func {
+        export namespace Request {
+            export type QueryParams = {
+                name: 'foo' | 'bar'
+            }
+        }
+
+        export type Response = void
+    }
+}

--- a/test/serverless-query-param-type/api.d.ts
+++ b/test/serverless-query-param-type/api.d.ts
@@ -1,8 +1,10 @@
 export namespace ProjectApi {
     export namespace Func {
         export namespace Request {
-            export type QueryParams = {
-                name: 'foo' | 'bar'
+            export namespace QueryParams {
+                export type name =
+                     'foo' | 'bar'
+
             }
         }
 

--- a/test/serverless-query-param-type/resources/serverless.yml
+++ b/test/serverless-query-param-type/resources/serverless.yml
@@ -1,0 +1,32 @@
+service: serverless-openapi-typescript-demo
+provider:
+  name: aws
+
+plugins:
+  - ../node_modules/@conqa/serverless-openapi-documentation
+  - ../src/index
+
+custom:
+  documentation:
+    title: 'Project'
+    description: DummyDescription
+    apiNamespace: ProjectApi
+
+functions:
+  func:
+    handler: handler.create
+    events:
+      - http:
+          documentation:
+            summary: "Create Function"
+            description: |
+              Create Function1
+              Create Function2
+              Create Function3
+          path: create
+          method: post
+          request:
+            parameters:
+              querystrings:
+                name: true
+

--- a/test/serverless-query-param-type/resources/serverless.yml
+++ b/test/serverless-query-param-type/resources/serverless.yml
@@ -26,4 +26,6 @@ functions:
             parameters:
               querystrings:
                 name: true
+                other: false
+                another: true
 

--- a/test/serverless-query-param-type/resources/serverless.yml
+++ b/test/serverless-query-param-type/resources/serverless.yml
@@ -18,13 +18,10 @@ functions:
     events:
       - http:
           documentation:
-            summary: "Create Function"
-            description: |
-              Create Function1
-              Create Function2
-              Create Function3
-          path: create
-          method: post
+            summary: "Get Function"
+            description: ''
+          path: get
+          method: get
           request:
             parameters:
               querystrings:


### PR DESCRIPTION
### use hide whitespaces for the review

Add support for query param types
this will generate the types we find under the 
```
export namespace ProjectApi {
    export namespace Func {
        export namespace Request {
            export namespace QueryParams {
				...
			}
		}
	}
}
```

For example:
```
api.d.ts:

export namespace ProjectApi {
    export namespace Func {
        export namespace Request {
            export namespace QueryParams {
				export type name: 'foo' | 'bar'
			}
		}
	}
}

serverless:

functions:
  func:
    handler: handler.create
    events:
      - http:
          documentation:
            summary: "Get Function"
            description: ''
          path: get
          method: get
          request:
            parameters:
              querystrings:
                name: true
```

it will search the `name` under the `ProjectApi.Func.Request.QueryParams` namespace, if we found one we will generate that
else
we will use the current `schema: {type: string}`

