### PR TITLE
Allow json output

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-openapi-typescript",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "An extension of @conqa/serverless-openapi-documentation that also generates your OpenAPI models from TypeScript",
   "main": "dist/index.js",
   "scripts": {

--- a/src/serverless-openapi-typescript.ts
+++ b/src/serverless-openapi-typescript.ts
@@ -171,7 +171,7 @@ export default class ServerlessOpenapiTypeScript {
         const openApi = yaml.load(fs.readFileSync(outputFile));
         this.patchOpenApiVersion(openApi);
         this.tagMethods(openApi);
-        fs.writeFileSync(outputFile, yaml.dump(openApi));
+        fs.writeFileSync(outputFile, outputFile.endsWith('json') ? JSON.stringify(openApi, null, 2) : yaml.dump(openApi));
     }
 
     patchOpenApiVersion(openApi) {


### PR DESCRIPTION
When an output of `.json` suffix is set, the produced file will be of `json` type rather than `yaml`