### PR TITLE
Expose query and path parameters as models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-openapi-typescript",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-openapi-typescript",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-openapi-typescript",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "An extension of @conqa/serverless-openapi-documentation that also generates your OpenAPI models from TypeScript",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-openapi-typescript",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "An extension of @conqa/serverless-openapi-documentation that also generates your OpenAPI models from TypeScript",
   "main": "dist/index.js",
   "scripts": {

--- a/src/serverless-openapi-typescript.ts
+++ b/src/serverless-openapi-typescript.ts
@@ -162,6 +162,19 @@ export default class ServerlessOpenapiTypeScript {
                         responseModels: { 'application/json': responseModelName }
                     }
                 ]);
+
+                const queryParamModel = `${definitionPrefix}.Request.QueryParams`;
+                try {
+                    this.setModel(queryParamModel);
+                } catch (e) {
+                    this.log(`Skipped generation of "${queryParamModel}" - most a model is missing - will be using the default query param of type string`);
+                }
+
+                const pathParamModel = `${definitionPrefix}.Request.PathParams`;
+                try {
+                    this.log(`Skipped generation of "${pathParamModel}" - most a model is missing - will be using the default path param of type string`);
+                    this.setModel(pathParamModel);
+                } catch (e) {}
         }
     }
 

--- a/src/serverless-openapi-typescript.ts
+++ b/src/serverless-openapi-typescript.ts
@@ -171,7 +171,7 @@ export default class ServerlessOpenapiTypeScript {
         const openApi = yaml.load(fs.readFileSync(outputFile));
         this.patchOpenApiVersion(openApi);
         this.tagMethods(openApi);
-        fs.writeFileSync(outputFile, yaml.dump(openApi));
+        fs.writeFileSync(outputFile, outputFile.endsWith('json') ? JSON.stringify(openApi, null, 2) : yaml.dump(openApi));
     }
 
     patchOpenApiVersion(openApi) {


### PR DESCRIPTION
Exposing models of query and path parameters to allow JSON schema validation by 3rd parties