### PR TITLE
bump ts-json-schema-generator version from 0.95 -> 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "ts-json-schema-generator": "^0.95.0",
+    "ts-json-schema-generator": "^1.0.0",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-openapi-typescript",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "An extension of @conqa/serverless-openapi-documentation that also generates your OpenAPI models from TypeScript",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
https://github.com/vega/ts-json-schema-generator/releases/tag/v1.0.0
many enhancements and bugfixes some highlights of what I noticed are:
- correctly parse $id and $comment JSDoc tags  
- parse jsdoc tags using json5
- support template literals as types
- support intrinsic string manipulation types