### PR TITLE
Chore: Handle http events list

### DIFF
--- a/src/serverless-openapi-typescript.ts
+++ b/src/serverless-openapi-typescript.ts
@@ -223,9 +223,9 @@ export default class ServerlessOpenapiTypeScript {
         if (customTags) openApi.tags = openApi.tags.concat(customTags)
 
         Object.values(openApi.paths).forEach(path => {
-            Object.values(path).forEach(method => {
+            Object.entries(path).forEach(([methodName, method]) => {
                 const httpEvent = this.functions[method.operationId]?.events?.find(
-                    (e: ApiGatewayEvent) => e.http
+                    (e: ApiGatewayEvent) => (e.http as any).method === methodName
                 ) as ApiGatewayEvent;
                 const http: HttpEvent = httpEvent.http;
                 if (http.documentation?.tag) {
@@ -234,7 +234,7 @@ export default class ServerlessOpenapiTypeScript {
                     method.tags = [tagName];
                 }
 
-                method.operationId = kebabCase(`${this.serverless.service.custom?.documentation?.title}-${method.operationId}`);
+                method.operationId = kebabCase(`${this.serverless.service.custom?.documentation?.title}-${method.operationId}-${methodName}`);
             });
         });
     }

--- a/test/fixtures/expect-openapi-custom-tags.yml
+++ b/test/fixtures/expect-openapi-custom-tags.yml
@@ -13,7 +13,7 @@ info:
 paths:
   /create:
     post:
-      operationId: project-create-func
+      operationId: project-create-func-post
       summary: Create Function
       description: |
         Create Function1
@@ -37,7 +37,7 @@ paths:
         - FooBarTitle
   /delete:
     delete:
-      operationId: project-delete-func
+      operationId: project-delete-func-delete
       summary: Delete Function
       description: Delete
       parameters: []
@@ -49,7 +49,7 @@ paths:
         - Project
   /get:
     get:
-      operationId: project-get-func
+      operationId: project-get-func-get
       summary: Get Function
       parameters: []
       responses:

--- a/test/fixtures/expect-openapi-full.yml
+++ b/test/fixtures/expect-openapi-full.yml
@@ -109,7 +109,7 @@ info:
 paths:
   /create/{funcName}:
     post:
-      operationId: project-create-func
+      operationId: project-create-func-post
       summary: Create Function
       description: |
         Create Function1
@@ -163,7 +163,7 @@ paths:
         - Project
   /delete/{funcName}:
     delete:
-      operationId: project-delete-func
+      operationId: project-delete-func-delete
       summary: Delete Function
       description: Delete
       parameters:
@@ -181,7 +181,7 @@ paths:
         - Project
   /update:
     put:
-      operationId: project-update-func
+      operationId: project-update-func-put
       summary: Delete Function
       description: Delete
       requestBody:
@@ -202,7 +202,7 @@ paths:
         - Project
   /get/{funcName}:
     get:
-      operationId: project-get-func
+      operationId: project-get-func-get
       summary: Get Function
       parameters:
         - name: funcName

--- a/test/fixtures/expect-openapi-hyphenated-functions.yml
+++ b/test/fixtures/expect-openapi-hyphenated-functions.yml
@@ -13,7 +13,7 @@ info:
 paths:
   /create:
     post:
-      operationId: project-create-func
+      operationId: project-create-func-post
       summary: Create Function
       description: |
         Create Function1
@@ -37,7 +37,7 @@ paths:
         - FooBarTitle
   /delete:
     delete:
-      operationId: project-delete-all-func
+      operationId: project-delete-all-func-delete
       summary: Delete Function
       description: Delete
       parameters: []
@@ -49,7 +49,7 @@ paths:
         - Project
   /get:
     get:
-      operationId: project-get-func
+      operationId: project-get-func-get
       summary: Get Function
       parameters: []
       responses:

--- a/test/fixtures/expect-openapi-query-param-type.yml
+++ b/test/fixtures/expect-openapi-query-param-type.yml
@@ -14,7 +14,7 @@ info:
 paths:
   /get:
     get:
-      operationId: func
+      operationId: func-get
       summary: Get Function
       parameters:
         - name: name


### PR DESCRIPTION
When creating a lambda which have many http triggers, we generate the same `operationId` to all of them.
The solution here is to add the method to the end of the `operationId` making it unique.