### PR TITLE
Chore: Only change operation id for functions with many events

### DIFF
--- a/src/serverless-openapi-typescript.ts
+++ b/src/serverless-openapi-typescript.ts
@@ -224,7 +224,8 @@ export default class ServerlessOpenapiTypeScript {
 
         Object.values(openApi.paths).forEach(path => {
             Object.entries(path).forEach(([methodName, method]) => {
-                const httpEvent = this.functions[method.operationId]?.events?.find(
+                const httpEvents = this.functions[method.operationId]?.events;
+                const httpEvent = httpEvents?.find(
                     (e: ApiGatewayEvent) => (e.http as any).method === methodName
                 ) as ApiGatewayEvent;
                 const http: HttpEvent = httpEvent.http;
@@ -234,7 +235,7 @@ export default class ServerlessOpenapiTypeScript {
                     method.tags = [tagName];
                 }
 
-                method.operationId = kebabCase(`${this.serverless.service.custom?.documentation?.title}-${method.operationId}-${methodName}`);
+                method.operationId = kebabCase(`${this.serverless.service.custom?.documentation?.title}-${method.operationId}${httpEvents.length > 1 ? `-${methodName}`: ''}`);
             });
         });
     }

--- a/test/fixtures/expect-openapi-custom-tags.yml
+++ b/test/fixtures/expect-openapi-custom-tags.yml
@@ -13,7 +13,7 @@ info:
 paths:
   /create:
     post:
-      operationId: project-create-func-post
+      operationId: project-create-func
       summary: Create Function
       description: |
         Create Function1
@@ -37,7 +37,7 @@ paths:
         - FooBarTitle
   /delete:
     delete:
-      operationId: project-delete-func-delete
+      operationId: project-delete-func
       summary: Delete Function
       description: Delete
       parameters: []
@@ -49,7 +49,7 @@ paths:
         - Project
   /get:
     get:
-      operationId: project-get-func-get
+      operationId: project-get-func
       summary: Get Function
       parameters: []
       responses:

--- a/test/fixtures/expect-openapi-hyphenated-functions.yml
+++ b/test/fixtures/expect-openapi-hyphenated-functions.yml
@@ -13,7 +13,7 @@ info:
 paths:
   /create:
     post:
-      operationId: project-create-func-post
+      operationId: project-create-func
       summary: Create Function
       description: |
         Create Function1
@@ -37,7 +37,7 @@ paths:
         - FooBarTitle
   /delete:
     delete:
-      operationId: project-delete-all-func-delete
+      operationId: project-delete-all-func
       summary: Delete Function
       description: Delete
       parameters: []
@@ -49,7 +49,7 @@ paths:
         - Project
   /get:
     get:
-      operationId: project-get-func-get
+      operationId: project-get-func
       summary: Get Function
       parameters: []
       responses:

--- a/test/fixtures/expect-openapi-trigger-events-list.yml
+++ b/test/fixtures/expect-openapi-trigger-events-list.yml
@@ -37,7 +37,7 @@ components:
           type: string
         generic:
           $ref: >-
-            #/components/schemas/ProjectApi.GenericType_structure-1448918441-633-661-1448918441-620-662-1448918441-599-663-1448918441-547-673-1448918441-515-674-1448918441-283-680-1448918441-250-680-1448918441-104-1213-1448918441-75-1213-1448918441-0-1214_
+            #/components/schemas/ProjectApi.GenericType_structure-1660319619-633-661-1660319619-620-662-1660319619-599-663-1660319619-547-673-1660319619-515-674-1660319619-283-680-1660319619-250-680-1660319619-104-1213-1660319619-75-1213-1660319619-0-1214_
       required:
         - id
         - uuid
@@ -70,7 +70,7 @@ components:
       required:
         - data
       additionalProperties: false
-    ProjectApi.GenericType_structure-1448918441-633-661-1448918441-620-662-1448918441-599-663-1448918441-547-673-1448918441-515-674-1448918441-283-680-1448918441-250-680-1448918441-104-1213-1448918441-75-1213-1448918441-0-1214_:
+    ProjectApi.GenericType_structure-1660319619-633-661-1660319619-620-662-1660319619-599-663-1660319619-547-673-1660319619-515-674-1660319619-283-680-1660319619-250-680-1660319619-104-1213-1660319619-75-1213-1660319619-0-1214_:
       type: array
       items:
         type: object
@@ -181,7 +181,27 @@ paths:
         - Project
   /update:
     put:
-      operationId: project-update-func
+      operationId: project-update-func-put
+      summary: Delete Function
+      description: Delete
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectApi.UpdateFunc.Request.Body'
+        description: ''
+      parameters: []
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectApi.UpdateFunc.Response'
+      tags:
+        - Project
+    post:
+      operationId: project-update-func-post
       summary: Delete Function
       description: Delete
       requestBody:

--- a/test/serverless-openapi-typescript.spec.ts
+++ b/test/serverless-openapi-typescript.spec.ts
@@ -16,6 +16,7 @@ describe('ServerlessOpenapiTypeScript', () => {
     ${'Custom Tags'}  | ${'custom-tags'}
     ${'Hyphenated Functions'}  | ${'hyphenated-functions'}
     ${'Full Project'} | ${'full'}
+    ${'Trigger Events List'}|${'trigger-events-list'}
     `('when using $testCase', ({projectName}) => {
 
         beforeEach(async () => {

--- a/test/serverless-trigger-events-list/api.d.ts
+++ b/test/serverless-trigger-events-list/api.d.ts
@@ -1,0 +1,55 @@
+interface ObjectType {
+    types?: string[];
+    children?: ObjectType[];
+}
+
+export namespace ProjectApi {
+    export type Bool = 'true' | 'false';
+    export type Number = number
+    export type String = string;
+    export type GenericType<T> = T[];
+
+    export namespace CreateFunc {
+        export namespace Request {
+            export type Body = {
+                data: string;
+                statusCode?: number;
+                enable: boolean;
+                object?: ObjectType;
+            };
+        }
+
+        export type Response = {
+            id: string;
+            uuid: string;
+            generic: GenericType<{ key: string, name: number}>;
+        };
+    }
+
+    export namespace DeleteFunc {
+        export namespace Request {
+            export type Body = {
+                id: string;
+            };
+        }
+    }
+
+    export namespace UpdateFunc {
+        export namespace Request {
+            export type Body = {
+                id: string;
+                data: string;
+            };
+        }
+
+        export type Response = {
+            id: string;
+        };
+    }
+
+    export namespace GetFunc {
+        export type Response = {
+            data: string;
+        };
+    }
+}

--- a/test/serverless-trigger-events-list/resources/serverless.yml
+++ b/test/serverless-trigger-events-list/resources/serverless.yml
@@ -1,0 +1,105 @@
+service: serverless-openapi-typescript-demo
+provider:
+  name: aws
+
+plugins:
+  - ../node_modules/@conqa/serverless-openapi-documentation
+  - ../src/index
+
+custom:
+  documentation:
+    title: 'Project'
+    description: |
+      It is a long established fact that a reader will be distracted by the readable content of a
+      page when looking at its layout. The point of using Lorem Ipsum is that
+      it has a more-or-less normal distribution of letters, as opposed to using
+      'Content here, content here', making it look like readable English. Many desktop publishing
+      packages and web page editors now use Lorem Ipsum as their default model text, and a search
+      for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years,
+      sometimes by accident, sometimes on purpose (injected humour and the like).
+
+      More on https://google.com
+    apiNamespace: ProjectApi
+
+functions:
+  createFunc:
+    handler: handler.create
+    events:
+      - http:
+          documentation:
+            summary: "Create Function"
+            description: |
+              Create Function1
+              Create Function2
+              Create Function3
+            queryParams:
+              - name: 'param1'
+                description: 'Param 1'
+                schema: 'ProjectApi.Bool'
+              - name: 'param2'
+                description: 'Param 2'
+                schema: 'ProjectApi.String'
+              - name: 'param3'
+                description: 'Param 3'
+                schema: 'ProjectApi.Number'
+          path: create/{funcName}
+          method: post
+          request:
+            parameters:
+              paths:
+                funcName: true
+              querystrings:
+                param1: false
+                param2: true
+                param3: false
+
+  deleteFunc:
+    handler: handler.delete
+    events:
+      - http:
+          documentation:
+            summary: "Delete Function"
+            description: "Delete"
+          path: delete/{funcName}
+          method: delete
+          request:
+            parameters:
+              paths:
+                funcName: true
+
+  updateFunc:
+    handler: handler.update
+    events:
+      - http:
+          documentation:
+            summary: "Delete Function"
+            description: "Delete"
+          path: update
+          method: put
+      - http:
+          documentation:
+            summary: "Delete Function"
+            description: "Delete"
+          path: update
+          method: post
+
+  getFunc:
+    handler: handler.update
+    events:
+      - http:
+          documentation:
+            summary: "Get Function"
+          path: get/{funcName}
+          method: get
+          request:
+            parameters:
+              paths:
+                funcName: true
+
+  internalFunc:
+    handler: handler.internal
+    events:
+      - http:
+          documentation: ~
+          path: internal
+          method: get


### PR DESCRIPTION
Only add the event method to the operation id when there are many events that trigger the function to not hurt other users' usage