### PR TITLE
Support for webhoooks tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,26 @@ export namespace MyApi {
 }
 ```
 
+You can also add Webhook tags by using `webhookTags` keyword it will auto add tag to all webhooks
+```yaml
+custom:
+  documentation:
+    apiNamespace: MyApi
+    webhookTags:
+      - name: ProjectWebhooks
+        description: This is the description for ProjectWebhooks
+    webhooks:
+      WebhookName:
+        post:
+          requestBody:
+            description: |
+              This is a request body description
+          responses:
+            200:
+              description: |
+                This is a expected response description
+```
+
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-openapi-typescript",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "An extension of @conqa/serverless-openapi-documentation that also generates your OpenAPI models from TypeScript",
   "main": "dist/index.js",
   "scripts": {

--- a/src/serverless-openapi-typescript.ts
+++ b/src/serverless-openapi-typescript.ts
@@ -69,6 +69,10 @@ export default class ServerlessOpenapiTypeScript {
       return this.serverless.service.custom.documentation.webhooks || {};
     }
 
+    get webhookTags() {
+      return (this.serverless.service.custom.documentation.webhookTags || []).map(tag => tag.name);
+    }
+
     log(msg) {
         this.serverless.cli.log(`[serverless-openapi-typescript] ${msg}`);
     }
@@ -104,6 +108,7 @@ export default class ServerlessOpenapiTypeScript {
           const webhook = this.webhooks[webhookName];
           const methodDefinition = webhook['post'];
           if (methodDefinition) {
+            methodDefinition.tags = this.webhookTags;
             this.setWebhookModels(methodDefinition, webhookName);
             this.log(`Generating docs for webhook ${webhookName}`);
           }

--- a/test/fixtures/expect-openapi-full.yml
+++ b/test/fixtures/expect-openapi-full.yml
@@ -247,6 +247,7 @@ webhooks:
         '200':
           description: |
             This is a expected response description
+      tags: []
 tags:
   - name: Project
     description: >

--- a/test/fixtures/expect-openapi-webhooks-custom-tags.yml
+++ b/test/fixtures/expect-openapi-webhooks-custom-tags.yml
@@ -13,7 +13,7 @@ components:
         - name
       additionalProperties: false
 info:
-  title: Project
+  title: ProjectApi
   description: DummyDescription
 paths: { }
 webhooks:
@@ -31,11 +31,8 @@ webhooks:
         '200':
           description: |
             This is a expected response description
-      tags: []
+      tags:
+        - ProjectWebhooks
 tags:
-  - name: Project
+  - name: ProjectApi
     description: DummyDescription
-  - name: FooBarTitle
-    description: FooBarDescription
-  - name: BazTitle
-    description: BazDescription

--- a/test/serverless-openapi-typescript.spec.ts
+++ b/test/serverless-openapi-typescript.spec.ts
@@ -17,6 +17,7 @@ describe('ServerlessOpenapiTypeScript', () => {
     ${'Hyphenated Functions'}  | ${'hyphenated-functions'}
     ${'Full Project'} | ${'full'}
     ${'Webhooks'} | ${'webhooks'}
+    ${'Webhooks Tags'} | ${'webhooks-custom-tags'}
     `('when using $testCase', ({projectName}) => {
 
         beforeEach(async () => {

--- a/test/serverless-webhooks-custom-tags/api.d.ts
+++ b/test/serverless-webhooks-custom-tags/api.d.ts
@@ -1,0 +1,8 @@
+export namespace ProjectApi {
+  export namespace Webhooks {
+    export type OnCreateWebhook = {
+      id: string;
+      name: string;
+    }
+  }
+}

--- a/test/serverless-webhooks-custom-tags/resources/serverless.yml
+++ b/test/serverless-webhooks-custom-tags/resources/serverless.yml
@@ -1,0 +1,26 @@
+service: serverless-openapi-typescript-demo
+provider:
+  name: aws
+
+plugins:
+  - ../node_modules/@conqa/serverless-openapi-documentation
+  - ../src/index
+
+custom:
+  documentation:
+    title: 'ProjectApi'
+    description: DummyDescription
+    apiNamespace: ProjectApi
+    webhookTags:
+      - name: ProjectWebhooks
+        description: This is the description for ProjectWebhooks
+    webhooks:
+      OnCreateWebhook:
+        post:
+          requestBody:
+            description: |
+              This is a request body description
+          responses:
+            200:
+              description: |
+                This is a expected response description


### PR DESCRIPTION
Add support for tag property for webhooks
It will append the `custom.webhookTags` into the webhook `tags` section of openapi spec file